### PR TITLE
Created Postgres table json config, entity and repository for Students Table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Student.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Student.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "students")
+public class Student {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private Long courseId;
+  private String fname;
+  private String lname;
+  private String studentId;
+  private String email;
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/StudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/StudentRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import edu.ucsb.cs156.happiercows.entities.Student;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudentRepository extends CrudRepository<Student, Integer> {
+}

--- a/src/main/resources/db/migration/changes/StudentTable.json
+++ b/src/main/resources/db/migration/changes/StudentTable.json
@@ -1,0 +1,79 @@
+{ "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "changeset-0001",
+        "author": "smmzhu",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "STUDENTS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "CONSTRAINT_68"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COURSE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "FNAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "GITHUB_ID",
+                    "type": "INT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "LNAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STUDENT_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                }]
+              ,
+              "tableName": "STUDENTS"
+            }
+          }]
+        
+      }
+    }  
+  ]
+}


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
First ticket in a series tackling issue #26 — creating the entity and repository files for the STUDENTS Postgres Table.

Testing Link: https://sampr2.dokku-11.cs.ucsb.edu/

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
Note: this validation only works if you pull and test on localhost since H2 is only accessible on localhost. Otherwise, validation can only be performed by testing subsequent endpoints on Swagger (since the Postgres table working is a pre-requisite endpoints working).
1. Open the link.
2. Go into H2.
3. Verify with `SELECT * FROM STUDENTS;` query to make sure the STUDENTS table is accessible.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100%
- [ ] ~~Frontend Unit tests (`npm test`) pass~~
- [ ] ~~Frontend Test coverage (`npm run coverage`) 100%~~
- [ ] ~~Frontend Mutation tests (`npx stryker run`) 100%~~ 
- [ ] ~~Frontend Linting (`npx eslint --fix src`)~~ 

## Linked Issues
<!--Issues related to the PR-->
Closes #34 
