### PR TITLE
Added Post Endpoint for single record in students table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/StudentController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/StudentController.java
@@ -5,6 +5,7 @@ import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.repositories.StudentRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,26 @@ public class StudentController extends ApiController {
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException(Student.class, id));
         return student;
+    }
+
+    @Operation(summary = "Post a new student")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("")
+    public Student postStudent(
+        @Parameter(name = "courseId") @RequestParam Long courseId,
+        @Parameter(name = "fname") @RequestParam String fname,
+        @Parameter(name = "lname") @RequestParam String lname,
+        @Parameter(name = "studentId") @RequestParam String studentId,
+        @Parameter(name = "email") @RequestParam String email
+    ) {
+        Student student = new Student();
+        student.setCourseId(courseId);
+        student.setFname(fname);
+        student.setLname(lname);
+        student.setStudentId(studentId);
+        student.setEmail(email);
+        
+        return studentRepository.save(student);
     }
 }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/StudentController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/StudentController.java
@@ -1,7 +1,9 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
 import edu.ucsb.cs156.happiercows.entities.Student;
+import edu.ucsb.cs156.happiercows.entities.Courses;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.repositories.CoursesRepository;
 import edu.ucsb.cs156.happiercows.repositories.StudentRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +27,9 @@ public class StudentController extends ApiController {
     @Autowired
     StudentRepository studentRepository;
 
+    @Autowired
+    CoursesRepository coursesRepository;
+
     @Operation(summary = "Get student by id")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
@@ -46,6 +51,9 @@ public class StudentController extends ApiController {
         @Parameter(name = "studentId") @RequestParam String studentId,
         @Parameter(name = "email") @RequestParam String email
     ) {
+
+        coursesRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Courses.class, courseId));
+
         Student student = new Student();
         student.setCourseId(courseId);
         student.setFname(fname);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
@@ -6,7 +6,7 @@ import javax.persistence.*;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Builder
 @Entity(name = "courses")
 public class Courses {

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/StudentControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/StudentControllerTests.java
@@ -2,17 +2,16 @@ package edu.ucsb.cs156.happiercows.controllers;
 
 
 import edu.ucsb.cs156.happiercows.testconfig.TestConfig;
-import lombok.With;
 
 import org.springframework.context.annotation.Import;
 
 import edu.ucsb.cs156.happiercows.entities.Student;
-import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.entities.Courses;
 import edu.ucsb.cs156.happiercows.repositories.StudentRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CoursesRepository;
 
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -25,7 +24,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.Optional;
@@ -46,6 +44,10 @@ public class StudentControllerTests extends ControllerTestCase {
 
     @MockBean
     UserRepository userRepository;
+
+    @MockBean
+    CoursesRepository courseRepository;
+
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -98,7 +100,11 @@ public class StudentControllerTests extends ControllerTestCase {
         student.setStudentId("12345");
         student.setEmail("8TbGZ@example.com");
 
+        Courses course = new Courses();
+        course.setId(1L);
+
         when(studentRepository.save(student)).thenReturn(student);
+        when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
         
         MvcResult response = mockMvc.perform(post("/api/students")
             .param("courseId", "1")
@@ -118,5 +124,29 @@ public class StudentControllerTests extends ControllerTestCase {
         assertEquals("12345", json.get("studentId"));
         assertEquals("8TbGZ@example.com", json.get("email"));
         assertEquals(1, (Integer)json.get("courseId"));   
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void post_throws_entity_not_found_exception_when_courseid_does_not_exist() throws Exception {
+        Student student = new Student();
+        student.setId(0L);
+        student.setCourseId(1L);
+        student.setFname("John");
+        student.setLname("Doe");
+        student.setStudentId("12345");
+        student.setEmail("8TbGZ@example.com");
+
+        when(studentRepository.save(student)).thenReturn(student);
+        when(courseRepository.findById(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/students")
+            .param("courseId", "1")
+            .param("fname", "John")
+            .param("lname", "Doe")  
+            .param("studentId", "12345")
+            .param("email", "8TbGZ@example.com")
+            .with(csrf()))
+            .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
(Merge https://github.com/ucsb-cs156-f24/proj-happycows-f24-11/pull/30 before this one)
Third ticket in a series tackling issue https://github.com/ucsb-cs156-f24/proj-happycows-f24-11/issues/26 — added Post Endpoint for single record in students table.
Testing Link: https://sampr2.dokku-11.cs.ucsb.edu/

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/409f4d9c-59da-476f-b4cc-98a22b1d5ce6">

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Open swagger.
2. Make sure the post endpoint is visible.
3. Test with an example query that the endpoint works as intended.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] ~~Frontend Unit tests (`npm test`) pass~~
- [ ] ~~Frontend Test coverage (`npm run coverage`) 100%~~
- [ ] ~~Frontend Mutation tests (`npx stryker run`) 100%~~ 
- [ ] ~~Frontend Linting (`npx eslint --fix src`)~~ 

## Linked Issues
<!--Issues related to the PR-->
Closes #35 
