### PR TITLE
GetAllByCourseId Endpoint added — GET endpoint for multiple students objects in table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/StudentController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/StudentController.java
@@ -34,5 +34,14 @@ public class StudentController extends ApiController {
             .orElseThrow(() -> new EntityNotFoundException(Student.class, id));
         return student;
     }
+
+    @Operation(summary = "Get all students by course id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/course")
+    public Iterable<Student> getByCourseId(@RequestParam Long courseId) throws EntityNotFoundException
+    {
+        Iterable<Student> students = studentRepository.findAllByCourseId(courseId);
+        return students;
+    }
 }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/StudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/StudentRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 @Repository
 public interface StudentRepository extends CrudRepository<Student, Integer> {
     Optional<Student> findById(Long id);
+    Iterable<Student> findAllByCourseId(Long courseId);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/StudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/StudentRepository.java
@@ -5,6 +5,7 @@ import edu.ucsb.cs156.happiercows.entities.Student;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+
 import java.util.Optional;
 
 @Repository

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/StudentControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/StudentControllerTests.java
@@ -79,4 +79,41 @@ public class StudentControllerTests extends ControllerTestCase {
         mockMvc.perform(get("/api/students?id=1"))
                 .andExpect(status().isNotFound());
     }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_users_can_get_by_course_id() throws Exception {
+        Student student1 = new Student();
+        student1.setId(1L);
+        student1.setCourseId(1L);
+        student1.setFname("John");
+        student1.setLname("Doe");
+        student1.setStudentId("12345");
+        student1.setEmail("8TbGZ@example.com");
+
+        Student student2 = new Student();
+        student2.setId(2L);
+        student2.setCourseId(1L);
+        student2.setFname("Jane");
+        student2.setLname("Doe");
+        student2.setStudentId("54321");
+        student2.setEmail("0yNt9@example.com");
+
+        when(studentRepository.findAllByCourseId(1L)).thenReturn(java.util.Arrays.asList(student1, student2));
+        mockMvc.perform(get("/api/students/course?courseId=1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].courseId").value(1))
+                .andExpect(jsonPath("$[0].fname").value("John"))
+                .andExpect(jsonPath("$[0].lname").value("Doe"))
+                .andExpect(jsonPath("$[0].studentId").value("12345"))
+                .andExpect(jsonPath("$[0].email").value("8TbGZ@example.com"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].courseId").value(1))
+                .andExpect(jsonPath("$[1].fname").value("Jane"))
+                .andExpect(jsonPath("$[1].lname").value("Doe"))
+                .andExpect(jsonPath("$[1].studentId").value("54321"))
+                .andExpect(jsonPath("$[1].email").value("0yNt9@example.com"));
+    }
 }


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
(Merge #30 before this one)
Fourth ticket in a series tackling issue #26 — GetAllByCourseId Endpoint added. GET endpoint for multiple students objects with same CourseId.

Testing link [here](https://sampr1.dokku-11.cs.ucsb.edu)

## Screenshots (Optional)
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/3d05e7be-fcbb-498c-ad7e-54d6ac2cfaa6">

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
This endpoint may have to be paginated in the future since the max load could be upwards of 850 students (in the worst case of Campbell Hall).

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Go into Swagger. Use the students Post request to create student objects in the table with the same CourseId.
2. Validate this endpoint by using the endpoint to get the student objects back.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] ~~Frontend Unit tests (`npm test`) pass~~
- [ ] ~~Frontend Test coverage (`npm run coverage`) 100%~~
- [ ] ~~Frontend Mutation tests (`npx stryker run`) 100%~~ 
- [ ] ~~Frontend Linting (`npx eslint --fix src`)~~

## Linked Issues
<!--Issues related to the PR-->
Closes #32 
