### PR TITLE
Added Frontend Delete Button Component and Modal Component for DELETE Operation for Announcements

### DIFF
--- a/frontend/src/main/components/Announcement/AnnouncementTable.js
+++ b/frontend/src/main/components/Announcement/AnnouncementTable.js
@@ -1,59 +1,114 @@
-import React from "react";
-import OurTable, { ButtonColumn } from "main/components/OurTable";
-
-import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/announcementUtils"
-import { useNavigate } from "react-router-dom";
-import { hasRole } from "main/utils/currentUser";
+import React, { useState } from 'react';
+import OurTable, { ButtonColumn } from 'main/components/OurTable';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+import { useBackendMutation } from 'main/utils/useBackend';
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from 'main/utils/announcementUtils';
+import { useNavigate } from 'react-router-dom';
+import { hasRole } from 'main/utils/currentUser';
+import { useParams } from 'react-router-dom';
 
 export default function AnnouncementTable({ announcements, currentUser }) {
+  const navigate = useNavigate();
+  const { commonsId } = useParams();
 
-    const navigate = useNavigate();
+  const [showModal, setShowModal] = useState(false);
+  const [cellToDelete, setCellToDelete] = useState(null);
 
-    const editCallback = (cell) => {
-        navigate(`/announcements/edit/${cell.row.values.id}`)
-    }
+  const editCallback = (cell) => {
+    navigate(`/announcements/edit/${cell.row.values.id}`);
+  };
 
-    // Stryker disable all : hard to test for query caching
+  // Stryker disable all : hard to test for query caching
 
-    const deleteMutation = useBackendMutation(
-        cellToAxiosParamsDelete,
-        { onSuccess: onDeleteSuccess },
-        ["/api/announcements/all"]
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    [`/api/announcements/getbycommonsid?commonsId=${commonsId}`]
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    setCellToDelete(cell);
+    setShowModal(true);
+  };
+
+  const confirmDelete = async (cell) => {
+    deleteMutation.mutate(cell);
+    setShowModal(false);
+  };
+
+  const columns = [
+    {
+      Header: 'id',
+      accessor: 'id', // accessor is the "key" in the data
+    },
+    {
+      Header: 'Start Date ISO Format',
+      accessor: 'startDate',
+    },
+    {
+      Header: 'End Date ISO Format',
+      accessor: 'endDate',
+    },
+    {
+      Header: 'Announcement',
+      accessor: 'announcementText',
+    },
+  ];
+
+  if (hasRole(currentUser, 'ROLE_ADMIN')) {
+    columns.push(
+      ButtonColumn('Edit', 'primary', editCallback, 'AnnouncementTable')
     );
-    // Stryker restore all 
+    columns.push(
+      ButtonColumn('Delete', 'danger', deleteCallback, 'AnnouncementTable')
+    );
+  }
 
-    // Stryker disable next-line all : TODO try to make a good test for this
-    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+  const announcementsModal = (
+    <Modal
+      data-testid="AnnouncementsTable-Modal"
+      show={showModal}
+      onHide={() => setShowModal(false)}
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>Confirm Deletion</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        Are you sure you want to delete this announcement?
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          variant="secondary"
+          data-testid="AnnouncementTable-Modal-Cancel"
+          onClick={() => setShowModal(false)}
+        >
+          Keep this Announcement
+        </Button>
+        <Button
+          variant="danger"
+          data-testid="AnnouncementTable-Modal-Delete"
+          onClick={() => confirmDelete(cellToDelete)}
+        >
+          Permanently Delete
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
 
-
-    const columns = [
-        {
-            Header: 'id',
-            accessor: 'id', // accessor is the "key" in the data
-        },
-        {
-            Header: 'Start Date ISO Format',
-            accessor: 'startDate',
-        },
-        {
-            Header: 'End Date ISO Format',
-            accessor: 'endDate',
-        },
-        {
-            Header: 'Announcement',
-            accessor: 'announcementText',
-        }
-    ];
-
-    if (hasRole(currentUser, "ROLE_ADMIN")) {
-        columns.push(ButtonColumn("Edit", "primary", editCallback, "AnnouncementTable"));
-        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "AnnouncementTable"));
-    } 
-
-    return <OurTable
+  return (
+    <>
+      <OurTable
         data={announcements}
         columns={columns}
-        testid={"AnnouncementTable"}
-    />;
-};
+        testid={'AnnouncementTable'}
+      />
+      {hasRole(currentUser, 'ROLE_ADMIN') && announcementsModal}
+    </>
+  );
+}

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -9,7 +9,7 @@ import { useCurrentUser } from 'main/utils/currentUser';
 
 export default function AdminAnnouncementsPage() {
   const { commonsId } = useParams();
-  const currentUser = useCurrentUser();
+  const { data: currentUser } = useCurrentUser();
 
   // Stryker disable all
   const { data: commonsPlus } = useBackend(

--- a/frontend/src/main/utils/announcementUtils.js
+++ b/frontend/src/main/utils/announcementUtils.js
@@ -1,16 +1,16 @@
-import { toast } from "react-toastify";
+import { toast } from 'react-toastify';
 
 export function onDeleteSuccess(message) {
-    console.log(message);
-    toast(message);
+  console.log(message);
+  toast(message);
 }
 
 export function cellToAxiosParamsDelete(cell) {
-    return {
-        url: "/api/announcements",
-        method: "DELETE",
-        params: {
-            id: cell.row.values.id
-        }
-    }
+  return {
+    url: `/api/announcements/delete/${cell.row.values.id}`,
+    method: 'DELETE',
+    params: {
+      id: cell.row.values.id,
+    },
+  };
 }

--- a/frontend/src/main/utils/announcementUtils.js
+++ b/frontend/src/main/utils/announcementUtils.js
@@ -9,8 +9,5 @@ export function cellToAxiosParamsDelete(cell) {
   return {
     url: `/api/announcements/delete/${cell.row.values.id}`,
     method: 'DELETE',
-    params: {
-      id: cell.row.values.id,
-    },
   };
 }

--- a/frontend/src/tests/components/Announcement/AnnouncementsTable.test.js
+++ b/frontend/src/tests/components/Announcement/AnnouncementsTable.test.js
@@ -276,12 +276,6 @@ describe('Modal tests', () => {
   test('Clicking Permanently Delete button deletes the announcement', async () => {
     const currentUser = currentUserFixtures.adminUser;
 
-    // https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
-    const useBackendMutationSpy = jest.spyOn(
-      useBackendModule,
-      'useBackendMutation'
-    );
-
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>

--- a/frontend/src/tests/components/Announcement/AnnouncementsTable.test.js
+++ b/frontend/src/tests/components/Announcement/AnnouncementsTable.test.js
@@ -1,27 +1,32 @@
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
-import { announcementFixtures } from "fixtures/announcementFixtures";
-import AnnouncementTable from "main/components/Announcement/AnnouncementTable";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { fireEvent, render, waitFor, screen } from '@testing-library/react';
+import { announcementFixtures } from 'fixtures/announcementFixtures';
+import AnnouncementTable from 'main/components/Announcement/AnnouncementTable';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
+import * as useBackendModule from 'main/utils/useBackend';
 
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedNavigate
+  useNavigate: () => mockedNavigate,
 }));
 
-describe("AnnouncementTable tests", () => {
+describe('AnnouncementTable tests', () => {
   const queryClient = new QueryClient();
 
-  const expectedHeaders = ["id", "Start Date ISO Format", "End Date ISO Format", "Announcement"];
-  const expectedFields = ["id", "startDate", "endDate", "announcementText"];
-  const testId = "AnnouncementTable";
+  const expectedHeaders = [
+    'id',
+    'Start Date ISO Format',
+    'End Date ISO Format',
+    'Announcement',
+  ];
+  const expectedFields = ['id', 'startDate', 'endDate', 'announcementText'];
+  const testId = 'AnnouncementTable';
 
-  test("renders empty table correctly", () => {
-    
+  test('renders empty table correctly', () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
 
@@ -41,12 +46,14 @@ describe("AnnouncementTable tests", () => {
     });
 
     expectedFields.forEach((field) => {
-      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`
+      );
       expect(fieldElement).not.toBeInTheDocument();
     });
   });
 
-  test("Has the expected column headers, content and buttons for admin user", () => {
+  test('Has the expected column headers, content and buttons for admin user', () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
 
@@ -54,7 +61,10 @@ describe("AnnouncementTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <AnnouncementTable announcements={announcementFixtures.threeAnnouncements} currentUser={currentUser} />
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>
     );
@@ -70,23 +80,34 @@ describe("AnnouncementTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-startDate`)).toHaveTextContent("2024-12-12T00:00:00");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      '1'
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-startDate`)
+    ).toHaveTextContent('2024-12-12T00:00:00');
 
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-startDate`)).toHaveTextContent("2022-12-12T00:00:00");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      '2'
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-startDate`)
+    ).toHaveTextContent('2022-12-12T00:00:00');
 
-    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`
+    );
     expect(editButton).toBeInTheDocument();
-    expect(editButton).toHaveClass("btn-primary");
+    expect(editButton).toHaveClass('btn-primary');
 
-    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`
+    );
     expect(deleteButton).toBeInTheDocument();
-    expect(deleteButton).toHaveClass("btn-danger");
-
+    expect(deleteButton).toHaveClass('btn-danger');
   });
 
-  test("Has the expected column headers, content for ordinary user", () => {
+  test('Has the expected column headers, content for ordinary user', () => {
     // arrange
     const currentUser = currentUserFixtures.userOnly;
 
@@ -94,7 +115,10 @@ describe("AnnouncementTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <AnnouncementTable announcements={announcementFixtures.threeAnnouncements} currentUser={currentUser} />
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>
     );
@@ -110,18 +134,25 @@ describe("AnnouncementTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-startDate`)).toHaveTextContent("2024-12-12T00:00:00");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      '1'
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-startDate`)
+    ).toHaveTextContent('2024-12-12T00:00:00');
 
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-startDate`)).toHaveTextContent("2022-12-12T00:00:00");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      '2'
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-startDate`)
+    ).toHaveTextContent('2022-12-12T00:00:00');
 
-    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
-    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
   });
 
-
-  test("Edit button navigates to the edit page", async () => {
+  test('Edit button navigates to the edit page', async () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
 
@@ -129,27 +160,37 @@ describe("AnnouncementTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <AnnouncementTable announcements={announcementFixtures.threeAnnouncements} currentUser={currentUser} />
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>
     );
 
     // assert - check that the expected content is rendered
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-startDate`)).toHaveTextContent("2024-12-12T00:00:00");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      '1'
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-startDate`)
+    ).toHaveTextContent('2024-12-12T00:00:00');
 
-    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`
+    );
     expect(editButton).toBeInTheDocument();
 
     // act - click the edit button
     fireEvent.click(editButton);
 
     // assert - check that the navigate function was called with the expected path
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/announcements/edit/1'));
-
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith('/announcements/edit/1')
+    );
   });
 
-  test("Delete button calls delete callback", async () => {
+  test('Delete button calls delete callback', async () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
 
@@ -157,19 +198,183 @@ describe("AnnouncementTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <AnnouncementTable announcements={announcementFixtures.threeAnnouncements} currentUser={currentUser} />
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>
     );
 
     // assert - check that the expected content is rendered
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-startDate`)).toHaveTextContent("2024-12-12T00:00:00");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      '1'
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-startDate`)
+    ).toHaveTextContent('2024-12-12T00:00:00');
 
-    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`
+    );
     expect(deleteButton).toBeInTheDocument();
 
     // act - click the delete button
     fireEvent.click(deleteButton);
+  });
+});
+
+describe('Modal tests', () => {
+  const queryClient = new QueryClient();
+
+  // Mocking the delete mutation function
+  const mockMutate = jest.fn();
+  const mockUseBackendMutation = {
+    mutate: mockMutate,
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(useBackendModule, 'useBackendMutation')
+      .mockReturnValue(mockUseBackendMutation);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('Clicking Delete button opens the modal for adminUser', async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+
+    const deleteButton = screen.getByTestId(
+      'AnnouncementTable-cell-row-0-col-Delete-button'
+    );
+    fireEvent.click(deleteButton);
+
+    // Verify that the modal is shown by checking for the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).toHaveClass('modal-open');
+    });
+  });
+
+  test('Clicking Permanently Delete button deletes the announcement', async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    // https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
+    const useBackendMutationSpy = jest.spyOn(
+      useBackendModule,
+      'useBackendMutation'
+    );
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const deleteButton = screen.getByTestId(
+      'AnnouncementTable-cell-row-0-col-Delete-button'
+    );
+    fireEvent.click(deleteButton);
+
+    const permanentlyDeleteButton = await screen.findByTestId(
+      'AnnouncementTable-Modal-Delete'
+    );
+    fireEvent.click(permanentlyDeleteButton);
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+  });
+
+  test('Clicking Keep this Announcement button cancels the deletion', async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const deleteButton = screen.getByTestId(
+      'AnnouncementTable-cell-row-0-col-Delete-button'
+    );
+    fireEvent.click(deleteButton);
+
+    const cancelButton = await screen.findByTestId(
+      'AnnouncementTable-Modal-Cancel'
+    );
+    fireEvent.click(cancelButton);
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test('Pressing the escape key on the modal cancels the deletion', async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AnnouncementTable
+            announcements={announcementFixtures.threeAnnouncements}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Click the delete button to open the modal
+    const deleteButton = screen.getByTestId(
+      'AnnouncementTable-cell-row-0-col-Delete-button'
+    );
+    fireEvent.click(deleteButton);
+
+    // Check that the modal is displayed by checking for the "modal-open" class in the body
+    expect(document.body).toHaveClass('modal-open');
+
+    // Click the close button
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+
+    // Assert that the delete mutation was not called
+    // (you'll need to replace `mockMutate` with the actual reference to the mutation in your code)
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/tests/utils/announcementUtils.test.js
+++ b/frontend/src/tests/utils/announcementUtils.test.js
@@ -1,58 +1,50 @@
-import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/announcementUtils";
-import mockConsole from "jest-mock-console";
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from 'main/utils/announcementUtils';
+import mockConsole from 'jest-mock-console';
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
+  const originalModule = jest.requireActual('react-toastify');
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
 });
 
-describe("AnnouncementUtils", () => {
+describe('AnnouncementUtils', () => {
+  describe('onDeleteSuccess', () => {
+    test('It puts the message on console.log and in a toast', () => {
+      // arrange
+      const restoreConsole = mockConsole();
 
-    describe("onDeleteSuccess", () => {
+      // act
+      onDeleteSuccess('abc');
 
-        test("It puts the message on console.log and in a toast", () => {
-            // arrange
-            const restoreConsole = mockConsole();
+      // assert
+      expect(mockToast).toHaveBeenCalledWith('abc');
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch('abc');
 
-            // act
-            onDeleteSuccess("abc");
-
-            // assert
-            expect(mockToast).toHaveBeenCalledWith("abc");
-            expect(console.log).toHaveBeenCalled();
-            const message = console.log.mock.calls[0][0];
-            expect(message).toMatch("abc");
-
-            restoreConsole();
-        });
-
+      restoreConsole();
     });
-    describe("cellToAxiosParamsDelete", () => {
+  });
+  describe('cellToAxiosParamsDelete', () => {
+    test('It returns the correct params', () => {
+      // arrange
+      const cell = { row: { values: { id: 1 } } };
 
-        test("It returns the correct params", () => {
-            // arrange
-            const cell = { row: { values: { id: 1 } } };
+      // act
+      const result = cellToAxiosParamsDelete(cell);
 
-            // act
-            const result = cellToAxiosParamsDelete(cell);
-
-            // assert
-            expect(result).toEqual({
-                url: "/api/announcements",
-                method: "DELETE",
-                params: { id: 1 }
-            });
-        });
-
+      // assert
+      expect(result).toEqual({
+        url: '/api/announcements/delete/1',
+        method: 'DELETE',
+      });
     });
+  });
 });
-
-
-
-
-

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -186,8 +186,8 @@ public class AnnouncementsController extends ApiController{
 
     @Operation(summary = "Delete an announcement", description = "Delete an announcement associated with an id")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
-    @DeleteMapping("/delete")
-    public ResponseEntity<Object> deleteAnnouncement(@Parameter(description = "The id of the chat message") @RequestParam Long id) {
+    @DeleteMapping("/delete/{id}")
+    public Object deleteAnnouncement(@Parameter(description = "The id of the chat message") @PathVariable Long id) {
 
         // Try to get the chat message
         Optional<Announcement> announcementLookup = announcementRepository.findByAnnouncementId(id);
@@ -201,7 +201,8 @@ public class AnnouncementsController extends ApiController{
 
         // Hide the message
         announcementRepository.delete(announcementObj);
-        return ResponseEntity.ok(announcementObj);
+        String responseString = String.format("announcement with id %d deleted", id);
+        return genericMessage(responseString);
     }
 
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -10,13 +10,14 @@ import static org.mockito.ArgumentMatchers.any;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Date;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 
-
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.Test;
@@ -251,7 +252,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.empty());
 
         //act 
-        mockMvc.perform(delete("/api/announcements/delete?id={id}", id).with(csrf()))
+        mockMvc.perform(delete("/api/announcements/delete/{id}", id).with(csrf()))
             .andExpect(status().isBadRequest()).andReturn();
 
         // assert
@@ -277,14 +278,14 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
 
         //act 
-        MvcResult response = mockMvc.perform(delete("/api/announcements/delete?id={id}", id).with(csrf()))
-            .andExpect(status().isOk()).andReturn();
+        MvcResult response = mockMvc.perform(delete("/api/announcements/delete/{id}", id).with(csrf()))
+            .andExpect(status().is(200)).andReturn();
 
         // assert
         verify(announcementRepository, atLeastOnce()).findByAnnouncementId(id);
         verify(announcementRepository, atLeastOnce()).delete(any(Announcement.class));
         String responseString = response.getResponse().getContentAsString();
-        String expectedResponseString = mapper.writeValueAsString(announcementObj);
+        String expectedResponseString = "{\"message\":\"announcement with id 0 deleted\"}";
         log.info("Got back from API: {}",responseString);
         assertEquals(expectedResponseString, responseString);
     }


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, admin users should be able to click the delete button next to an announcement located on the table component in order to delete an announcement. When the user clicks the button, a modal should show up indicating to the user whether they want to confirm or cancel the deletion.

## Screenshots
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
**Screenshot of Delete Button Component on Table**
<img width="836" alt="Screenshot 2024-11-26 at 2 36 13 AM" src="https://github.com/user-attachments/assets/879673b2-8c28-4d91-9f2a-7da06f7ab020">

**Screenshot of Delete Modal**
<img width="1197" alt="Screenshot 2024-11-26 at 2 36 40 AM" src="https://github.com/user-attachments/assets/398741ec-1573-403c-af3c-df5ac673e806">

Dokku Link: https://happycows-brianc2730-dev.dokku-11.cs.ucsb.edu/

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #17
